### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/src/main/java/com/web/board/domain/Article.java
+++ b/src/main/java/com/web/board/domain/Article.java
@@ -23,12 +23,21 @@ public class Article extends AuditingFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+    @Setter
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "userId")
+    private UserAccount userAccount; // 유저 정보 (ID)
 
-    @Setter @Column(nullable = false) private String title; // 제목
-    @Setter @Column(nullable = false, length = 10000) private String content; // 본문
+    @Setter
+    @Column(nullable = false)
+    private String title; // 제목
 
-    @Setter private String hashtag; // 해시태그
+    @Setter
+    @Column(nullable = false, length = 10000)
+    private String content; // 본문
+
+    @Setter
+    private String hashtag; // 해시태그
 
     @ToString.Exclude
     @OrderBy("createdAt DESC")
@@ -52,13 +61,13 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        if (!(o instanceof Article that)) return false;
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 
 }

--- a/src/main/java/com/web/board/domain/ArticleComment.java
+++ b/src/main/java/com/web/board/domain/ArticleComment.java
@@ -22,11 +22,18 @@ public class ArticleComment extends AuditingFields {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Setter @ManyToOne(optional = false) private Article article; // 게시글 (ID)
-    @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
+    @Setter
+    @ManyToOne(optional = false)
+    private Article article; // 게시글 (ID)
 
-    @Setter @Column(nullable = false, length = 500) private String content; // 본문
+    @Setter
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "userId")
+    private UserAccount userAccount; // 유저 정보 (ID)
 
+    @Setter
+    @Column(nullable = false, length = 500)
+    private String content; // 본문
 
     protected ArticleComment() {}
 
@@ -44,12 +51,12 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 
 }

--- a/src/main/java/com/web/board/domain/UserAccount.java
+++ b/src/main/java/com/web/board/domain/UserAccount.java
@@ -16,16 +16,25 @@ import java.util.Objects;
 })
 @Entity
 public class UserAccount extends AuditingFields {
+
     @Id
     @Column(length = 50)
     private String userId;
 
-    @Setter @Column(nullable = false) private String userPassword;
+    @Setter
+    @Column(nullable = false)
+    private String userPassword;
 
-    @Setter @Column(length = 100) private String email;
-    @Setter @Column(length = 100) private String nickname;
-    @Setter private String memo;
+    @Setter
+    @Column(length = 100)
+    private String email;
 
+    @Setter
+    @Column(length = 100)
+    private String nickname;
+
+    @Setter
+    private String memo;
 
     protected UserAccount() {}
 
@@ -48,7 +57,6 @@ public class UserAccount extends AuditingFields {
         return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
-    
     @Override
     public int hashCode() {
         return Objects.hash(this.getUserId());


### PR DESCRIPTION
이 pr은 엔티티의 equals(), hashcode()가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다. 프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.