### PR TITLE
[고도화] 민감 정보의 환경 변수 치환 후 테스트 실패 현상 수정

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -47,3 +47,9 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+
+---
+
+spring:
+  config.activate.on-profile: local-test
+  datasource.url: jdbc:h2:mem:testdb

--- a/src/test/java/com/web/board/WebProjectBoardApplicationTests.java
+++ b/src/test/java/com/web/board/WebProjectBoardApplicationTests.java
@@ -4,7 +4,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
+// @SpringBootTest는 초기 테스트 환경을 구성하면서 프로퍼티 파일의 설정을 참고한다.
+@ActiveProfiles("local-test")
 @SpringBootTest
 class WebProjectBoardApplicationTests {
 


### PR DESCRIPTION
@SpringBootTest는 초기 테스트 환경을 구성하면서 프로퍼티 파일의 설정을 참고하기 때문에 환경변수가 주입되지 않은 테스트 환경에서 의도하지 않은 동작을 보이며 실패할 수 있다.

This closes #56 