### PR TITLE
api 서비스들의 시큐리티 설정 업데이트

### DIFF
--- a/src/main/java/com/web/board/config/SecurityConfig.java
+++ b/src/main/java/com/web/board/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers("/api/**").permitAll()
                         .requestMatchers(
                                 HttpMethod.GET,
                                 "/",
@@ -49,6 +50,7 @@ public class SecurityConfig {
                                 .userService(oAuth2UserService)
                         )
                 )
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/api/**"))
                 .build();
     }
 


### PR DESCRIPTION
외부 서비스인 어드민 프로젝트에서 원활하게
게시판 서비스의 api를 이용할 수 있도록 보안 설정을 수정.

This closes #61 