### PR TITLE
Data REST API 설정 검토하기

### DIFF
--- a/src/main/java/com/web/board/config/DataRestConfig.java
+++ b/src/main/java/com/web/board/config/DataRestConfig.java
@@ -2,6 +2,7 @@ package com.web.board.config;
 
 import com.web.board.domain.Article;
 import com.web.board.domain.ArticleComment;
+import com.web.board.domain.Hashtag;
 import com.web.board.domain.UserAccount;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,9 +16,9 @@ public class DataRestConfig {
         return RepositoryRestConfigurer.withConfig((config, cors) ->
                 config
                         .exposeIdsFor(UserAccount.class)
-//                        .exposeIdsFor(Article.class)
-//                        .exposeIdsFor(ArticleComment.class)
-//                        .exposeIdsFor(Hashtag.class)
+                        .exposeIdsFor(Article.class)
+                        .exposeIdsFor(ArticleComment.class)
+                        .exposeIdsFor(Hashtag.class)
         );
     }
 

--- a/src/main/java/com/web/board/controller/projection/ArticleCommentProjection.java
+++ b/src/main/java/com/web/board/controller/projection/ArticleCommentProjection.java
@@ -1,0 +1,19 @@
+package com.web.board.controller.projection;
+
+import com.web.board.domain.ArticleComment;
+import com.web.board.domain.UserAccount;
+import org.springframework.data.rest.core.config.Projection;
+
+import java.time.LocalDateTime;
+
+@Projection(name = "withUserAccount", types = ArticleComment.class)
+public interface ArticleCommentProjection {
+    Long getId();
+    UserAccount getUserAccount();
+    Long getParentCommentId();
+    String getContent();
+    LocalDateTime getCreatedAt();
+    String getCreatedBy();
+    LocalDateTime getModifiedAt();
+    String getModifiedBy();
+}

--- a/src/main/java/com/web/board/controller/projection/ArticleProjection.java
+++ b/src/main/java/com/web/board/controller/projection/ArticleProjection.java
@@ -1,0 +1,20 @@
+package com.web.board.controller.projection;
+
+import com.web.board.domain.Article;
+import com.web.board.domain.ArticleComment;
+import com.web.board.domain.UserAccount;
+import org.springframework.data.rest.core.config.Projection;
+
+import java.time.LocalDateTime;
+
+@Projection(name ="withUserAccount", types = Article.class)
+public interface ArticleProjection {
+    Long getId();
+    UserAccount getUserAccount();
+    String getTitle();
+    String getContent();
+    LocalDateTime getCreatedAt();
+    String getCreatedBy();
+    LocalDateTime getModifiedAt();
+    String getModifiedBy();
+}

--- a/src/main/java/com/web/board/controller/projection/UserAccountProjection.java
+++ b/src/main/java/com/web/board/controller/projection/UserAccountProjection.java
@@ -1,0 +1,18 @@
+package com.web.board.controller.projection;
+
+import com.web.board.domain.UserAccount;
+import org.springframework.data.rest.core.config.Projection;
+
+import java.time.LocalDateTime;
+
+@Projection(name ="withoutPassword", types = UserAccount.class)
+public interface UserAccountProjection {
+    String getUserId();
+    String getEmail();
+    String getNickname();
+    String getMemo();
+    LocalDateTime getCreatedAt();
+    String getCreatedBy();
+    LocalDateTime getModifiedAt();
+    String getModifiedBy();
+}

--- a/src/main/java/com/web/board/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/web/board/repository/ArticleCommentRepository.java
@@ -2,6 +2,7 @@ package com.web.board.repository;
 
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
+import com.web.board.controller.projection.ArticleCommentProjection;
 import com.web.board.domain.Article;
 import com.web.board.domain.ArticleComment;
 import com.web.board.domain.QArticle;
@@ -14,7 +15,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import java.util.List;
 
-@RepositoryRestResource
+@RepositoryRestResource(excerptProjection = ArticleCommentProjection.class)
 public interface ArticleCommentRepository extends
         JpaRepository<ArticleComment, Long>,
         /* ArticleComment 엔티티에 있는 기본 검색 기능 추가해줌 */

--- a/src/main/java/com/web/board/repository/ArticleRepository.java
+++ b/src/main/java/com/web/board/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.web.board.repository;
 
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
+import com.web.board.controller.projection.ArticleProjection;
 import com.web.board.domain.Article;
 import com.web.board.domain.QArticle;
 import com.web.board.repository.querydsl.ArticleRepositoryCustom;
@@ -13,7 +14,7 @@ import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@RepositoryRestResource
+@RepositoryRestResource(excerptProjection = ArticleProjection.class)
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
         ArticleRepositoryCustom,

--- a/src/main/java/com/web/board/repository/UserAccountRepository.java
+++ b/src/main/java/com/web/board/repository/UserAccountRepository.java
@@ -1,7 +1,10 @@
 package com.web.board.repository;
 
+import com.web.board.controller.projection.UserAccountProjection;
 import com.web.board.domain.UserAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource(excerptProjection = UserAccountProjection.class)
 public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
 }

--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -7,7 +7,7 @@
 
 <body>
 <footer class="container d-flex flex-wrap justify-content-between align-items-center py-3 my-4 border-top">
-    <p class="col-md-4 mb-0 text-muted">&copy; 2022 FastCampus, Inc</p>
+    <p class="col-md-4 mb-0 text-muted">&copy; 2024 Web Board Admin, Inc</p>
 
     <ul class="nav col-md-4 justify-content-end">
         <li class="nav-item"><a href="/" class="nav-link px-2 text-muted">Home</a></li>


### PR DESCRIPTION
data rest 가 자동 생성하는 api는 id 값을 노출하지 않는 것이 기본 설정.
이를 노출해준다. ( 수동으로 설정하기 위해 projection 기능 사용 )
id 값은 어드민 프로젝트의 테이블에서 관리 목적으로 보여줄 예정.

This closes #63 